### PR TITLE
Include new helper sources in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ set(PROJECT_SOURCES
         mainwindow.cpp
         mainwindow.h
         mainwindow.ui
+        IniSyntaxHighlighter.cpp
+        IniSyntaxHighlighter.h
+        emulatorutils.cpp
+        emulatorutils.h
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)


### PR DESCRIPTION
## Summary
- Add IniSyntaxHighlighter and emulatorutils sources to PROJECT_SOURCES so they are built with DemulEASY

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt package)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68b4e70741f88332b75345e473e14bea